### PR TITLE
Character encoding issue when downloading document

### DIFF
--- a/src/api/document-api.ts
+++ b/src/api/document-api.ts
@@ -58,7 +58,7 @@ export const documentApiFactory = (instance: AxiosInstance): DocumentApi => {
     createModificationDocument: async (id) =>
       instance.post<Document>(`/documents/${id}/create-modification-document`).then((r) => r.data),
 
-    download: async (id) => instance.get<string>(`/documents/${id}/download`).then((r) => r.data),
+    download: async (id) => instance.get<string>(`/documents/${id}/download`, {responseType: 'arraybuffer',responseEncoding: 'binary'}).then((r) => r.data),
     onlineSzamla: async (id) => instance.get<OnlineSzamlaStatus>(`/documents/${id}/online-szamla`).then((r) => r.data),
     listPaymentHistory: async (id) => instance.get<PaymentHistory[]>(`/documents/${id}/payments`).then((r) => r.data),
     updatePaymentHistory: async (id, payments) =>


### PR DESCRIPTION
Current behaviour: 
Downloaded PDF document renders blank due to incorrect encoding setting in Axios

By adding the below parameters Axios gets the file in binary format:
-  responseType: 'arraybuffer',
-  responseEncoding: 'binary'

Source:
https://stackoverflow.com/questions/40211246/encoding-issue-with-axios